### PR TITLE
Keep API credentials out of the response cache, plus QGIS 4 review follow-ups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,8 @@ on:
   schedule:
     - cron:  '0 6 * * 1'  # weekly check
 
-# The suite calls the live API on one shared key, so a branch's own in-flight run
-# is superseded. The schedule gets its own lane: a push must not kill the weekly
-# run, which is the canary for upstream image drift.
+# One shared API key, so runs must not overlap. The schedule keeps its own lane,
+# so a push cannot cancel the weekly run - the canary for upstream image drift.
 concurrency:
   group: tests-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -20,9 +19,7 @@ jobs:
       max-parallel: 2
       matrix:
         qgis_image:
-          # -trixie variants need QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox to start as root.
-          # qgis/qgis:4.0-questing is left out: it never reaches the --code script and
-          # burns the whole timeout instead of reporting anything.
+          # qgis/qgis:4.0-questing is left out: it never reaches the --code script
           - qgis/qgis:4.2-questing
           - qgis/qgis:3.44-bookworm
           - qgis/qgis:3.40-bookworm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,16 +13,17 @@ concurrency:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
         qgis_image:
-          # -trixie variants need QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox to start as root
+          # -trixie variants need QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox to start as root.
+          # qgis/qgis:4.0-questing is left out: it never reaches the --code script and
+          # burns the whole timeout instead of reporting anything.
           - qgis/qgis:4.2-questing
-          - qgis/qgis:4.0-questing
           - qgis/qgis:3.44-bookworm
           - qgis/qgis:3.40-bookworm
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,21 +3,24 @@ on:
   schedule:
     - cron:  '0 6 * * 1'  # weekly check
 
+# The suite calls the live API on one shared key, so a branch's own in-flight run
+# is superseded. The schedule gets its own lane: a push must not kill the weekly
+# run, which is the canary for upstream image drift.
+concurrency:
+  group: tests-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         qgis_image:
-          # NB: -questing is the variant the unsuffixed qgis/qgis:4.x tags point
-          # at. The -trixie variants cannot run the suite as-is: they bundle a
-          # QtWebEngine that refuses to start as root ("Running as root without
-          # --no-sandbox is not supported"), which kills QGIS before it reaches
-          # the --code script. Should we ever need them, setting
-          # QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox works around it.
+          # -trixie variants need QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox to start as root
           - qgis/qgis:4.2-questing
           - qgis/qgis:4.0-questing
           - qgis/qgis:3.44-bookworm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,8 @@ on:
   schedule:
     - cron:  '0 6 * * 1'  # weekly check
 
-# One shared API key, so runs must not overlap. The schedule keeps its own lane,
-# so a push cannot cancel the weekly run - the canary for upstream image drift.
+# The schedule keeps its own lane, so a push cannot cancel the weekly run - the
+# canary for upstream image drift.
 concurrency:
   group: tests-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,7 +16,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         qgis_image:
           # qgis/qgis:4.0-questing is left out: it never reaches the --code script

--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -5,15 +5,11 @@ services:
   tests:
     image: ${QGIS_IMAGE:?}
     volumes:
-      # mount the plugin and default config (enabling the plugin) into both the
-      # QGIS 3 and QGIS 4 profile locations, so the same service works with
-      # both qgis/qgis:3.x and qgis/qgis:4.x images. QGIS 4 renamed both the
-      # profile folder (QGIS3 -> QGIS4) and the settings ini, but the settings
-      # we need are identical, so qgis-profile.ini serves both under the name
-      # each generation expects. Each generation ignores the other's tree.
+      # mount the plugin into both profile trees; each generation ignores the other's
       - ../travel_time_platform_plugin:/root/.local/share/QGIS/QGIS3/profiles/default/python/plugins/travel_time_platform_plugin
-      - ../testing/qgis-profile.ini:/root/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini
       - ../travel_time_platform_plugin:/root/.local/share/QGIS/QGIS4/profiles/default/python/plugins/travel_time_platform_plugin
+      # default config (enabling the plugin), under the name each generation expects
+      - ../testing/qgis-profile.ini:/root/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini
       - ../testing/qgis-profile.ini:/root/.local/share/QGIS/QGIS4/profiles/default/QGIS/QGIS4.ini
       # include initialisation script (test launcher in QGIS)
       - ../testing/run_tests.py:/run_tests.py

--- a/travel_time_platform_plugin/algorithms/advanced.py
+++ b/travel_time_platform_plugin/algorithms/advanced.py
@@ -923,10 +923,10 @@ class TimeFilterAlgorithm(_SearchAlgorithmBase):
             output_fields.append(QgsField("prop_" + prop, QVariant.String, "text"))
 
         output_crs = locations.sourceCrs()
-        output_type = locations.wkbType()
+        output_wkb_type = locations.wkbType()
 
         (sink, sink_id) = self.parameterAsSink(
-            parameters, "OUTPUT", context, output_fields, output_type, output_crs
+            parameters, "OUTPUT", context, output_fields, output_wkb_type, output_crs
         )
 
         def clone_feature(id_):
@@ -1172,10 +1172,10 @@ class RoutesAlgorithm(_SearchAlgorithmBase):
             output_fields.append(QgsField("part_travel_time", QVariant.Int, "int"))
 
         output_crs = EPSG4326
-        output_type = Qgis.WkbType.LineString
+        output_wkb_type = Qgis.WkbType.LineString
 
         (sink, sink_id) = self.parameterAsSink(
-            parameters, "OUTPUT", context, output_fields, output_type, output_crs
+            parameters, "OUTPUT", context, output_fields, output_wkb_type, output_crs
         )
 
         for result in results:

--- a/travel_time_platform_plugin/algorithms/base.py
+++ b/travel_time_platform_plugin/algorithms/base.py
@@ -318,10 +318,9 @@ class ProcessingAlgorithmBase(AlgorithmBase):
         print_query = bool(QSettings().value("traveltime_platform/log_calls", False))
         if print_query:
             headers_for_logs = dict(headers)
-            if headers_for_logs["X-Application-Id"]:
-                headers_for_logs["X-Application-Id"] = "*hidden*"
-            if headers_for_logs["X-Api-Key"]:
-                headers_for_logs["X-Api-Key"] = "*hidden*"
+            for header in constants.CREDENTIAL_HEADERS:
+                if headers_for_logs[header]:
+                    headers_for_logs[header] = "*hidden*"
 
             log("Making request")
             log("url: {}".format(full_url))
@@ -404,20 +403,24 @@ class ProcessingAlgorithmBase(AlgorithmBase):
             log(e)
             raise QgsProcessingException("Could not decode response") from None
 
+        # The API answers with an object; a gateway in front of it may not
+        if not isinstance(response_data, dict):
+            response_data = {}
+
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
             nice_info = "\n".join(
                 "\t{}:\t{}".format(k, v)
-                for k, v in response_data["additional_info"].items()
+                for k, v in response_data.get("additional_info", {}).items()
             )
             feedback.reportError(
                 tr(
                     "Received error from the API.\nError code : {}\nDescription : {}\nSee : {}\nAddtionnal info :\n{}"
                 ).format(
-                    response_data["error_code"],
-                    response_data["description"],
-                    response_data["documentation_link"],
+                    response_data.get("error_code", response.status_code),
+                    response_data.get("description", response.reason),
+                    response_data.get("documentation_link", ""),
                     nice_info,
                 ),
                 fatalError=True,

--- a/travel_time_platform_plugin/algorithms/base.py
+++ b/travel_time_platform_plugin/algorithms/base.py
@@ -315,7 +315,9 @@ class ProcessingAlgorithmBase(AlgorithmBase):
         full_url = endpoint + self.url
 
         feedback.pushDebugInfo("Making request to API endpoint...")
-        print_query = bool(QSettings().value("traveltime_platform/log_calls", False))
+        print_query = QSettings().value(
+            "traveltime_platform/log_calls", False, type=bool
+        )
         if print_query:
             headers_for_logs = {
                 k: "*hidden*" if k in constants.CREDENTIAL_HEADERS else v

--- a/travel_time_platform_plugin/algorithms/base.py
+++ b/travel_time_platform_plugin/algorithms/base.py
@@ -317,10 +317,10 @@ class ProcessingAlgorithmBase(AlgorithmBase):
         feedback.pushDebugInfo("Making request to API endpoint...")
         print_query = bool(QSettings().value("traveltime_platform/log_calls", False))
         if print_query:
-            headers_for_logs = dict(headers)
-            for header in constants.CREDENTIAL_HEADERS:
-                if headers_for_logs[header]:
-                    headers_for_logs[header] = "*hidden*"
+            headers_for_logs = {
+                k: "*hidden*" if k in constants.CREDENTIAL_HEADERS else v
+                for k, v in headers.items()
+            }
 
             log("Making request")
             log("url: {}".format(full_url))
@@ -381,6 +381,17 @@ class ProcessingAlgorithmBase(AlgorithmBase):
             response = cache.instance.cached_requests.send(
                 request, verify=not disable_https
             )
+        except requests.exceptions.SSLError as e:
+            feedback.reportError(
+                tr(
+                    "Could not connect to the API because of an SSL certificate error. You can disable SSL verification in the plugin settings. See log for more details."
+                ),
+                fatalError=True,
+            )
+            log(e)
+            raise QgsProcessingException(
+                "Got an SSL error when connecting to the API"
+            ) from None
         except requests.exceptions.RequestException as e:
             feedback.reportError(
                 tr(
@@ -430,24 +441,6 @@ class ProcessingAlgorithmBase(AlgorithmBase):
             raise QgsProcessingException(
                 "Got error {} from API".format(response.status_code)
             ) from None
-        except requests.exceptions.SSLError as e:
-            feedback.reportError(
-                tr(
-                    "Could not connect to the API because of an SSL certificate error. You can disable SSL verification in the plugin settings. See log for more details."
-                ),
-                fatalError=True,
-            )
-            log(e)
-            raise QgsProcessingException(
-                "Got an SSL error when connecting to the API"
-            ) from None
-        except requests.exceptions.RequestException as e:
-            feedback.reportError(
-                tr("Could not connect to the API. See log for more details."),
-                fatalError=True,
-            )
-            log(e)
-            raise QgsProcessingException("Could not connect to API") from None
 
         if response.from_cache:
             feedback.pushDebugInfo("Got response from cache...")

--- a/travel_time_platform_plugin/cache.py
+++ b/travel_time_platform_plugin/cache.py
@@ -11,8 +11,6 @@ PURGED_SETTING = "traveltime_platform/cache_credentials_purged"
 
 
 class CredentialFreeCache(DbCache):
-    """Sqlite cache that keeps API credentials out of the cache file."""
-
     def _picklable_field(self, response, name):
         value = super()._picklable_field(response, name)
         if name == "request":

--- a/travel_time_platform_plugin/cache.py
+++ b/travel_time_platform_plugin/cache.py
@@ -1,8 +1,26 @@
 import os
 
-from qgis.PyQt.QtCore import QStandardPaths
+from qgis.PyQt.QtCore import QSettings, QStandardPaths
 
+from .constants import CREDENTIAL_HEADERS
 from .libraries import requests_cache
+from .libraries.requests_cache.backends import DbCache
+from .utils import log
+
+PURGED_SETTING = "traveltime_platform/cache_credentials_purged"
+
+
+class CredentialFreeCache(DbCache):
+    """Sqlite cache that keeps API credentials out of the cache file."""
+
+    def _picklable_field(self, response, name):
+        value = super()._picklable_field(response, name)
+        if name == "request":
+            # copy rather than mutate: the copy shares the live request's headers
+            value.headers = value.headers.copy()
+            for header in CREDENTIAL_HEADERS:
+                value.headers.pop(header, None)
+        return value
 
 
 class Cache:
@@ -34,12 +52,31 @@ class Cache:
         return "0b"
 
     def prepare(self):
+        cache_name = os.path.splitext(self.path)[0]
         self.cached_requests = requests_cache.core.CachedSession(
-            cache_name=os.path.splitext(self.path)[0],
-            backend="sqlite",
+            cache_name=cache_name,
+            backend=CredentialFreeCache(cache_name),
             expire_after=86400,
             allowable_methods=("GET", "POST"),
         )
+        self._purge_credentials_once()
+
+    def _purge_credentials_once(self):
+        """Entries written before CredentialFreeCache still hold the credentials.
+
+        Nothing evicts them on its own: expired entries go only when the same key
+        is requested again, so a one-off search would keep them indefinitely.
+        """
+        settings = QSettings()
+        if settings.value(PURGED_SETTING, False, type=bool):
+            return
+        try:
+            self.clear()
+        except Exception as e:
+            # runs during plugin import, and vacuum needs the file to itself
+            log(f"Could not purge the response cache, will retry next start: {e}")
+            return
+        settings.setValue(PURGED_SETTING, True)
 
 
 instance = Cache()

--- a/travel_time_platform_plugin/cache.py
+++ b/travel_time_platform_plugin/cache.py
@@ -14,7 +14,7 @@ class CredentialFreeCache(DbCache):
     def _picklable_field(self, response, name):
         value = super()._picklable_field(response, name)
         if name == "request":
-            # copy rather than mutate: the copy shares the live request's headers
+            # super() only shallow-copies, so these are still the live request's headers
             value.headers = value.headers.copy()
             for header in CREDENTIAL_HEADERS:
                 value.headers.pop(header, None)
@@ -60,9 +60,7 @@ class Cache:
         self._purge_credentials_once()
 
     def _purge_credentials_once(self):
-        """Entries written before CredentialFreeCache hold the credentials, and
-        nothing evicts them: an expired entry goes only when its key is asked for again.
-        """
+        """Entries from earlier versions hold credentials, and nothing else evicts them"""
         settings = QSettings()
         if settings.value(PURGED_SETTING, False, type=bool):
             return

--- a/travel_time_platform_plugin/cache.py
+++ b/travel_time_platform_plugin/cache.py
@@ -66,11 +66,22 @@ class Cache:
             return
         try:
             self.clear()
+            for path in self._sibling_cache_paths():
+                os.remove(path)
         except Exception as e:
             # runs during plugin import, and vacuum needs the file to itself
             log(f"Could not purge the response cache, will retry next start: {e}")
             return
         settings.setValue(PURGED_SETTING, True)
+
+    def _sibling_cache_paths(self):
+        """CacheLocation is per QGIS generation, so the other generation's file is ours"""
+        name = os.path.basename(self.path)
+        generations = os.path.dirname(os.path.dirname(self.path))
+        if not os.path.isdir(generations):
+            return []
+        paths = (os.path.join(generations, d, name) for d in os.listdir(generations))
+        return [p for p in paths if p != self.path and os.path.isfile(p)]
 
 
 instance = Cache()

--- a/travel_time_platform_plugin/cache.py
+++ b/travel_time_platform_plugin/cache.py
@@ -62,10 +62,8 @@ class Cache:
         self._purge_credentials_once()
 
     def _purge_credentials_once(self):
-        """Entries written before CredentialFreeCache still hold the credentials.
-
-        Nothing evicts them on its own: expired entries go only when the same key
-        is requested again, so a one-off search would keep them indefinitely.
+        """Entries written before CredentialFreeCache hold the credentials, and
+        nothing evicts them: an expired entry goes only when its key is asked for again.
         """
         settings = QSettings()
         if settings.value(PURGED_SETTING, False, type=bool):

--- a/travel_time_platform_plugin/constants.py
+++ b/travel_time_platform_plugin/constants.py
@@ -6,3 +6,6 @@ metadata.read(os.path.join(os.path.dirname(__file__), "metadata.txt"))
 
 TTP_VERSION = metadata["general"]["version"]
 DEFAULT_ENDPOINT = "https://api.traveltimeapp.com"
+
+# Must be kept out of logs and out of the response cache
+CREDENTIAL_HEADERS = ("X-Application-Id", "X-Api-Key")

--- a/travel_time_platform_plugin/main.py
+++ b/travel_time_platform_plugin/main.py
@@ -234,11 +234,10 @@ class TTPPlugin:
         treeview.scrollTo(xyz_tiles_group_idx[0])
 
         # If tiles were loaded, selected it
-        first_identifier = next(iter(self.tilesManager.tiles))
         ttp_tiles_idx = model.match(
             model.index(0, 0, xyz_tiles_group_idx[0]),
             Qt.ItemDataRole.DisplayRole,
-            self.tilesManager.browser_label(first_identifier),
+            self.tilesManager.default_browser_label(),
         )
         if len(ttp_tiles_idx) == 0:
             if tiles_added:

--- a/travel_time_platform_plugin/main.py
+++ b/travel_time_platform_plugin/main.py
@@ -234,12 +234,13 @@ class TTPPlugin:
         treeview.scrollTo(xyz_tiles_group_idx[0])
 
         # If tiles were loaded, selected it
-        lux_tiles_idx = model.match(
+        first_identifier = next(iter(self.tilesManager.tiles))
+        ttp_tiles_idx = model.match(
             model.index(0, 0, xyz_tiles_group_idx[0]),
             Qt.ItemDataRole.DisplayRole,
-            "TravelTime - Lux",
+            self.tilesManager.browser_label(first_identifier),
         )
-        if len(lux_tiles_idx) == 0:
+        if len(ttp_tiles_idx) == 0:
             # Shouldn't happen, but let's not crash
             self.iface.messageBar().pushMessage(
                 "Warning",
@@ -249,8 +250,8 @@ class TTPPlugin:
             return
 
         # Display it
-        treeview.setCurrentIndex(lux_tiles_idx[0])
-        treeview.scrollTo(lux_tiles_idx[0])
+        treeview.setCurrentIndex(ttp_tiles_idx[0])
+        treeview.scrollTo(ttp_tiles_idx[0])
 
     def show_config(self):
         self.config_dialog.exec()

--- a/travel_time_platform_plugin/main.py
+++ b/travel_time_platform_plugin/main.py
@@ -203,7 +203,7 @@ class TTPPlugin:
         self._dlg.show()
 
     def show_tiles(self):
-        self.tilesManager.add_tiles_to_browser()
+        tiles_added = self.tilesManager.add_tiles_to_browser()
 
         browser = self.iface.mainWindow().findChild(QDockWidget, "Browser")
         browser.setVisible(True)
@@ -241,12 +241,13 @@ class TTPPlugin:
             self.tilesManager.browser_label(first_identifier),
         )
         if len(ttp_tiles_idx) == 0:
-            # Shouldn't happen, but let's not crash
-            self.iface.messageBar().pushMessage(
-                "Warning",
-                tr("XYZ tiles were not added for an unknown reason"),
-                level=Qgis.MessageLevel.Warning,
-            )
+            if tiles_added:
+                # Shouldn't happen, but let's not crash
+                self.iface.messageBar().pushMessage(
+                    "Warning",
+                    tr("XYZ tiles were not added for an unknown reason"),
+                    level=Qgis.MessageLevel.Warning,
+                )
             return
 
         # Display it

--- a/travel_time_platform_plugin/metadata.txt
+++ b/travel_time_platform_plugin/metadata.txt
@@ -107,6 +107,7 @@ changelog=- 2019-02-12 : version 0.1-alpha
         - feature : QGIS 4 / Qt6 compatibility (still compatible with QGIS 3.40+)
         - fix : background maps work again (the tiles service moved), and the button now says why when they are unavailable
         - fix : API credentials are no longer kept in the response cache, which is cleared once when you upgrade
+        - fix : call logging no longer switches itself back on after a restart
 
 tags=travel,time,platform,api,distance,matrix,geocoder,geocode,geocoding,isochrone,isochrones,routing,polygon,polygons,network analysis,shortest path
 homepage=https://docs.traveltime.com/qgis/

--- a/travel_time_platform_plugin/metadata.txt
+++ b/travel_time_platform_plugin/metadata.txt
@@ -105,6 +105,8 @@ changelog=- 2019-02-12 : version 0.1-alpha
         - fix: make the plugin compatible with QGIS 3.40+ (and remove support for older versions)
     - 2026-08-10 : version 1.11.0
         - feature : QGIS 4 / Qt6 compatibility (still compatible with QGIS 3.40+)
+        - fix : background maps work again (the tiles service moved), and the button now says why when they are unavailable
+        - fix : API credentials are no longer kept in the response cache, which is cleared once when you upgrade
 
 tags=travel,time,platform,api,distance,matrix,geocoder,geocode,geocoding,isochrone,isochrones,routing,polygon,polygons,network analysis,shortest path
 homepage=https://docs.traveltime.com/qgis/

--- a/travel_time_platform_plugin/tests/tests_algorithms.py
+++ b/travel_time_platform_plugin/tests/tests_algorithms.py
@@ -2,8 +2,16 @@ import itertools
 import json
 
 import processing
-from qgis.core import QgsFeature, QgsProcessingUtils, QgsProject
+from qgis.core import (
+    Qgis,
+    QgsFeature,
+    QgsGeometry,
+    QgsPointXY,
+    QgsProcessingUtils,
+    QgsProject,
+)
 
+from ..algorithms.advanced import TimeMapAlgorithm
 from ..algorithms.simple import TRANSPORTATION_TYPES, TimeMapSimpleAlgorithm
 from ..constants import TTP_VERSION
 from ..utils import timezones
@@ -53,6 +61,8 @@ class AlgorithmsBasicTest(TestCaseBase):
             output_layer.metadata().keywords("TTP_VERSION")[0],
             TTP_VERSION,
         )
+
+        return output_layer
 
     def test_processing_time_map_simple(self):
         input_lyr = self._make_layer(["POINT(-3.1 55.9)"])
@@ -111,6 +121,37 @@ class AlgorithmsBasicTest(TestCaseBase):
             },
             expected_result_count=1,
         )
+
+    def test_processing_time_map_union(self):
+        # Far apart, so the union can only cover both if the searches were combined
+        london, edinburgh = QgsPointXY(-0.13, 51.5), QgsPointXY(-3.19, 55.95)
+        input_lyr_a = self._make_layer(
+            [
+                f"POINT({london.x()} {london.y()})",
+                f"POINT({edinburgh.x()} {edinburgh.y()})",
+            ]
+        )
+        output_layer = self._test_algorithm(
+            "ttp_v4:time_map",
+            {
+                "INPUT_DEPARTURE_SEARCHES": input_lyr_a.id(),
+                "INPUT_DEPARTURE_TIME": self._today_at_noon().isoformat(),
+                "INPUT_DEPARTURE_TRAVEL_TIME": "900",
+                "OUTPUT_RESULT_TYPE": TimeMapAlgorithm.RESULT_TYPE.index("UNION"),
+                "OUTPUT": "memory:",
+            },
+            expected_result_count=1,
+        )
+
+        # The aggregate must survive convertGeometryCollectionToSubclass as a polygon
+        feature = next(output_layer.getFeatures())
+        self.assertEqual(feature.attribute("id"), "UNION")
+        self.assertEqual(feature.geometry().type(), Qgis.GeometryType.Polygon)
+        for point in (london, edinburgh):
+            self.assertTrue(
+                feature.geometry().contains(QgsGeometry.fromPointXY(point)),
+                f"union does not cover {point.asWkt()}",
+            )
 
     def test_processing_time_filter(self):
         input_lyr_a = self._make_layer(["POINT(0.0 51.5)"], name="a")

--- a/travel_time_platform_plugin/tests/tests_algorithms.py
+++ b/travel_time_platform_plugin/tests/tests_algorithms.py
@@ -143,7 +143,7 @@ class AlgorithmsBasicTest(TestCaseBase):
             expected_result_count=1,
         )
 
-        # The aggregate must survive convertGeometryCollectionToSubclass as a polygon
+        # One polygon spanning both searches, not one search overwriting the other
         feature = next(output_layer.getFeatures())
         self.assertEqual(feature.attribute("id"), "UNION")
         self.assertEqual(feature.geometry().type(), Qgis.GeometryType.Polygon)

--- a/travel_time_platform_plugin/tests/tests_misc.py
+++ b/travel_time_platform_plugin/tests/tests_misc.py
@@ -40,8 +40,7 @@ class MiscTest(TestCaseBase):
         browser = iface.mainWindow().findChild(QDockWidget, "Browser")
         treeview = browser.findChild(QTreeView)
         model = treeview.model()
-        tiles_manager = self.plugin.tilesManager
-        expected_label = tiles_manager.browser_label(next(iter(tiles_manager.tiles)))
+        expected_label = self.plugin.tilesManager.default_browser_label()
 
         # Hide the browser
         browser.setVisible(False)

--- a/travel_time_platform_plugin/tests/tests_misc.py
+++ b/travel_time_platform_plugin/tests/tests_misc.py
@@ -1,4 +1,6 @@
+import os
 import pickle
+import shutil
 
 import processing
 import requests
@@ -15,7 +17,7 @@ from qgis.PyQt.QtCore import QSettings
 from qgis.PyQt.QtWidgets import QApplication, QDockWidget, QTreeView, QWidget
 from qgis.utils import iface
 
-from .. import auth, cache
+from .. import auth, cache, tiles
 from ..algorithms import base
 from ..constants import CREDENTIAL_HEADERS
 from ..utils import log
@@ -86,6 +88,91 @@ class MiscTest(TestCaseBase):
             self.assertIsNotNone(
                 settings.value(f"connections/xyz/items/{label}/url"), label
             )
+
+    def _legacy_cache_entry(self):
+        response = requests.Response()
+        response.status_code = 200
+        response._content = b"{}"
+        response.request = requests.Request(
+            "POST", "https://api.traveltimeapp.com/v4/time-map"
+        ).prepare()
+        return response
+
+    def test_cache_purges_once(self):
+        backend = cache.instance.cached_requests.cache
+        settings = QSettings()
+        # the cache dir is per QGIS generation, so the other generation's file is ours
+        generations = os.path.dirname(os.path.dirname(cache.instance.path))
+        sibling_dir = os.path.join(generations, "QGIS_other")
+        os.makedirs(sibling_dir, exist_ok=True)
+        sibling = os.path.join(sibling_dir, os.path.basename(cache.instance.path))
+        try:
+            with open(sibling, "wb") as f:
+                f.write(b"pretend this holds X-Api-Key")
+            backend.save_response("legacy-key", self._legacy_cache_entry())
+            settings.remove(cache.PURGED_SETTING)
+            cache.instance._purge_credentials_once()
+            self.assertFalse(backend.has_key("legacy-key"))
+            self.assertFalse(os.path.exists(sibling))
+            self.assertTrue(settings.value(cache.PURGED_SETTING, False, type=bool))
+
+            # having run once, it must not wipe a healthy cache on every start
+            backend.save_response("kept-key", self._legacy_cache_entry())
+            cache.instance._purge_credentials_once()
+            self.assertTrue(backend.has_key("kept-key"))
+
+            # a failed purge must stay pending rather than report success
+            settings.remove(cache.PURGED_SETTING)
+            original_clear = cache.instance.clear
+            cache.instance.clear = lambda: (_ for _ in ()).throw(OSError("locked"))
+            try:
+                cache.instance._purge_credentials_once()
+            finally:
+                cache.instance.clear = original_clear
+            self.assertFalse(settings.value(cache.PURGED_SETTING, False, type=bool))
+        finally:
+            settings.setValue(cache.PURGED_SETTING, True)
+            shutil.rmtree(sibling_dir, ignore_errors=True)
+
+    def test_tiles_keeps_live_entries_when_probe_fails(self):
+        tiles_manager = self.plugin.tilesManager
+        settings = QgsSettings()
+        items = "connections/xyz/items"
+        mine = f"{items}/TravelTime - Mine"
+        retired = f"{items}/TravelTime - Lux"
+        current = tiles_manager.default_browser_label()
+
+        cases = {
+            "unreachable": lambda *a, **kw: (_ for _ in ()).throw(OSError("refused")),
+            "blocked": lambda *a, **kw: self._html_response(),
+        }
+        for name, fake_get in cases.items():
+            with self.subTest(probe=name):
+                settings.setValue(
+                    f"{retired}/url", "https://tiles.traveltime.com/lux/1/2/3.png"
+                )
+                settings.setValue(f"{mine}/url", "https://example.com/{z}/{x}/{y}.png")
+                original_get = tiles.requests.get
+                tiles.requests.get = fake_get
+                try:
+                    self.assertFalse(tiles_manager.add_tiles_to_browser())
+                finally:
+                    tiles.requests.get = original_get
+
+                # ours and retired goes; the user's own entry under the prefix stays
+                self.assertIsNone(settings.value(f"{retired}/url"))
+                self.assertIsNotNone(settings.value(f"{mine}/url"))
+                settings.remove(mine)
+
+        # a failed probe must not have cost the user their working entries
+        tiles_manager.add_tiles_to_browser()
+        self.assertIsNotNone(settings.value(f"{items}/{current}/url"))
+
+    def _html_response(self):
+        response = requests.Response()
+        response.status_code = 200
+        response._content = b"<html>blocked"
+        return response
 
     def test_cache_omits_credentials(self):
         # lower case too: headers are matched case-insensitively over the wire

--- a/travel_time_platform_plugin/tests/tests_misc.py
+++ b/travel_time_platform_plugin/tests/tests_misc.py
@@ -1,14 +1,36 @@
+import pickle
+
+import processing
 import requests
 from processing import createAlgorithmDialog
-from qgis.core import Qgis, QgsPointXY, QgsProcessingContext, QgsProject, QgsSettings
+from qgis.core import (
+    QgsPointXY,
+    QgsProcessingContext,
+    QgsProcessingException,
+    QgsProcessingFeedback,
+    QgsProject,
+    QgsSettings,
+)
 from qgis.PyQt.QtCore import QSettings
 from qgis.PyQt.QtWidgets import QApplication, QDockWidget, QTreeView, QWidget
 from qgis.utils import iface
 
-from .. import cache
+from .. import auth, cache
+from ..algorithms import base
 from ..constants import CREDENTIAL_HEADERS
 from ..utils import log
 from .base import TestCaseBase
+
+
+class _CollectingFeedback(QgsProcessingFeedback):
+    """Keeps what the algorithm reported, which run() otherwise only logs"""
+
+    def __init__(self):
+        super().__init__()
+        self.errors = []
+
+    def reportError(self, error, fatalError=False):
+        self.errors.append(error)
 
 
 class MiscTest(TestCaseBase):
@@ -85,11 +107,81 @@ class MiscTest(TestCaseBase):
 
                 reduced = cache.instance.cached_requests.cache.reduce_response(response)
 
+                # what reaches the file is the pickle, not just this one field
+                pickled = pickle.dumps(reduced)
                 for header in CREDENTIAL_HEADERS:
                     self.assertNotIn(header, reduced.request.headers)
+                    self.assertNotIn(f"secret-{header}".encode(), pickled)
                     # the live request must keep them, or the call itself would fail
                     self.assertIn(header, request.headers)
                 self.assertEqual(reduced.request.headers["Accept"], "application/json")
+
+    def test_gateway_error_is_reported(self):
+        # A gateway in front of the API answers with a body the plugin does not expect
+        for body in (b'{"message":"upstream"}', b"[]"):
+            with self.subTest(body=body):
+                response = requests.Response()
+                response.status_code = 502
+                response.reason = "Bad Gateway"
+                response.url = "https://api.traveltimeapp.com/v4/time-map"
+                response._content = body
+                response.from_cache = False
+
+                session = cache.instance.cached_requests
+                original_send = session.send
+                session.send = lambda request, **kwargs: response
+                feedback = _CollectingFeedback()
+                try:
+                    with self.assertRaises(QgsProcessingException):
+                        processing.run(
+                            "ttp_v4:time_map",
+                            {
+                                "INPUT_DEPARTURE_SEARCHES": self._make_layer(
+                                    ["POINT(0.0 51.5)"]
+                                ).id(),
+                                "INPUT_DEPARTURE_TIME": self._today_at_noon().isoformat(),
+                                "INPUT_DEPARTURE_TRAVEL_TIME": "900",
+                                "OUTPUT": "memory:",
+                            },
+                            feedback=feedback,
+                        )
+                finally:
+                    session.send = original_send
+
+                # The status must reach the user rather than a KeyError or TypeError
+                joined = "\n".join(feedback.errors)
+                self.assertIn("502", joined)
+                self.assertIn("Bad Gateway", joined)
+
+    def test_log_calls_redacts_credentials(self):
+        settings = QSettings()
+        keys = {
+            "traveltime_platform/log_calls": True,
+            "traveltime_platform/custom_endpoint": "http://127.0.0.1:1",
+        }
+        previous = {k: settings.value(k) for k in keys}
+        for key, value in keys.items():
+            settings.setValue(key, value)
+
+        messages = []
+        original_log = base.log
+        base.log = lambda msg, *args, **kwargs: messages.append(str(msg))
+        try:
+            self.plugin.express_time_map_action.trigger()
+            self._feedback()
+            self._click(QgsPointXY(-0.13, 51.5))
+        finally:
+            base.log = original_log
+            for key, value in previous.items():
+                if value is None:
+                    settings.remove(key)
+                else:
+                    settings.setValue(key, value)
+
+        joined = "\n".join(messages)
+        self.assertIn("*hidden*", joined)
+        for secret in auth.get_app_id_and_api_key():
+            self.assertNotIn(secret, joined)
 
     def test_express_reports_api_error(self):
         settings = QSettings()
@@ -106,11 +198,10 @@ class MiscTest(TestCaseBase):
             else:
                 settings.setValue(endpoint_key, previous_endpoint)
 
-        # The failure must reach the message bar rather than escaping the tool
         item = iface.messageBar().currentItem()
-        self.assertIsNotNone(item)
         self.assertEqual(item.title(), "Error")
-        self.assertEqual(item.level(), Qgis.MessageLevel.Critical)
+        # an empty critical bubble is the failure this guards against
+        self.assertIn("Error while connecting to the API", item.text())
         self.assertEqual(QgsProject.instance().mapLayersByName("Output"), [])
 
     def test_skip_logic(self):

--- a/travel_time_platform_plugin/tests/tests_misc.py
+++ b/travel_time_platform_plugin/tests/tests_misc.py
@@ -1,6 +1,6 @@
 import requests
 from processing import createAlgorithmDialog
-from qgis.core import Qgis, QgsPointXY, QgsProcessingContext, QgsProject
+from qgis.core import Qgis, QgsPointXY, QgsProcessingContext, QgsProject, QgsSettings
 from qgis.PyQt.QtCore import QSettings
 from qgis.PyQt.QtWidgets import QApplication, QDockWidget, QTreeView, QWidget
 from qgis.utils import iface
@@ -47,6 +47,24 @@ class MiscTest(TestCaseBase):
             model.data(treeview.currentIndex()),
             expected_label,
         )
+
+    def test_tiles_drops_retired_entries(self):
+        tiles_manager = self.plugin.tilesManager
+        settings = QgsSettings()
+        retired = "connections/xyz/items/TravelTime - Lux"
+        settings.setValue(
+            f"{retired}/url", "https://tiles.traveltime.com/lux/1/2/3.png"
+        )
+
+        tiles_manager.add_tiles_to_browser()
+
+        # An upgrade must not leave the old style behind in the browser
+        self.assertIsNone(settings.value(f"{retired}/url"))
+        for identifier in tiles_manager.tiles:
+            label = tiles_manager.browser_label(identifier)
+            self.assertIsNotNone(
+                settings.value(f"connections/xyz/items/{label}/url"), label
+            )
 
     def test_cache_omits_credentials(self):
         # lower case too: headers are matched case-insensitively over the wire

--- a/travel_time_platform_plugin/tests/tests_misc.py
+++ b/travel_time_platform_plugin/tests/tests_misc.py
@@ -1,8 +1,12 @@
+import requests
 from processing import createAlgorithmDialog
-from qgis.core import QgsProcessingContext
+from qgis.core import Qgis, QgsPointXY, QgsProcessingContext, QgsProject
+from qgis.PyQt.QtCore import QSettings
 from qgis.PyQt.QtWidgets import QApplication, QDockWidget, QTreeView, QWidget
 from qgis.utils import iface
 
+from .. import cache
+from ..constants import CREDENTIAL_HEADERS
 from ..utils import log
 from .base import TestCaseBase
 
@@ -41,6 +45,53 @@ class MiscTest(TestCaseBase):
             model.data(treeview.currentIndex()),
             "TravelTime - Lux",
         )
+
+    def test_cache_omits_credentials(self):
+        # lower case too: headers are matched case-insensitively over the wire
+        for spelling in (str.title, str.lower):
+            with self.subTest(spelling=spelling.__name__):
+                request = requests.Request(
+                    "POST",
+                    "https://api.traveltimeapp.com/v4/time-map",
+                    headers={
+                        "Accept": "application/json",
+                        **{spelling(h): f"secret-{h}" for h in CREDENTIAL_HEADERS},
+                    },
+                ).prepare()
+                response = requests.Response()
+                response.status_code = 200
+                response._content = b"{}"
+                response.request = request
+
+                reduced = cache.instance.cached_requests.cache.reduce_response(response)
+
+                for header in CREDENTIAL_HEADERS:
+                    self.assertNotIn(header, reduced.request.headers)
+                    # the live request must keep them, or the call itself would fail
+                    self.assertIn(header, request.headers)
+                self.assertEqual(reduced.request.headers["Accept"], "application/json")
+
+    def test_express_reports_api_error(self):
+        settings = QSettings()
+        endpoint_key = "traveltime_platform/custom_endpoint"
+        previous_endpoint = settings.value(endpoint_key)
+        settings.setValue(endpoint_key, "http://127.0.0.1:1")
+        try:
+            self.plugin.express_time_map_action.trigger()
+            self._feedback()
+            self._click(QgsPointXY(-0.13, 51.5))
+        finally:
+            if previous_endpoint is None:
+                settings.remove(endpoint_key)
+            else:
+                settings.setValue(endpoint_key, previous_endpoint)
+
+        # The failure must reach the message bar rather than escaping the tool
+        item = iface.messageBar().currentItem()
+        self.assertIsNotNone(item)
+        self.assertEqual(item.title(), "Error")
+        self.assertEqual(item.level(), Qgis.MessageLevel.Critical)
+        self.assertEqual(QgsProject.instance().mapLayersByName("Output"), [])
 
     def test_skip_logic(self):
         dialog = createAlgorithmDialog("ttp_v4:time_map", {})

--- a/travel_time_platform_plugin/tests/tests_misc.py
+++ b/travel_time_platform_plugin/tests/tests_misc.py
@@ -18,6 +18,8 @@ class MiscTest(TestCaseBase):
         browser = iface.mainWindow().findChild(QDockWidget, "Browser")
         treeview = browser.findChild(QTreeView)
         model = treeview.model()
+        tiles_manager = self.plugin.tilesManager
+        expected_label = tiles_manager.browser_label(next(iter(tiles_manager.tiles)))
 
         # Hide the browser
         browser.setVisible(False)
@@ -31,7 +33,7 @@ class MiscTest(TestCaseBase):
         # Ensure the XYZ layer is not selected
         self.assertNotEqual(
             model.data(treeview.currentIndex()),
-            "TravelTime - Lux",
+            expected_label,
         )
 
         # Use the action
@@ -43,7 +45,7 @@ class MiscTest(TestCaseBase):
         # Ensure the XYZ layer got selected
         self.assertEqual(
             model.data(treeview.currentIndex()),
-            "TravelTime - Lux",
+            expected_label,
         )
 
     def test_cache_omits_credentials(self):

--- a/travel_time_platform_plugin/tiles.py
+++ b/travel_time_platform_plugin/tiles.py
@@ -42,14 +42,7 @@ class TilesManager:
                 url = self._get_url(identifier)
                 label = "TravelTime - " + label
 
-                # Not too sure why this changed in 3.30, maybe we're supposed to used
-                # the settings registry, but QgsXyzConnectionSettings isn't in the pyqgis
-                # bindings...
-                if Qgis.QGIS_VERSION_INT < 33000:
-                    settings_path = f"qgis/connections-xyz"
-                else:
-                    settings_path = f"connections/xyz/items"
-                settings_path += f"/{label}"
+                settings_path = f"connections/xyz/items/{label}"
                 s = QgsSettings()
                 s.setValue(f"{settings_path}/url", url)
                 s.setValue(f"{settings_path}/zmax", 20)

--- a/travel_time_platform_plugin/tiles.py
+++ b/travel_time_platform_plugin/tiles.py
@@ -3,7 +3,7 @@ from qgis.core import Qgis, QgsSettings
 from qgis.PyQt.QtCore import QSettings
 
 from . import auth
-from .utils import tr
+from .utils import log, tr
 
 
 class TilesManager:
@@ -26,8 +26,14 @@ class TilesManager:
     def add_tiles_to_browser(self):
         # We test access to tiles with API
         test_url = self._get_url(list(self.tiles.keys())[0])
-        response = requests.get(test_url.format(z=12, x=2048, y=1361))
-        has_tiles = response.ok
+        try:
+            response = requests.get(test_url.format(z=12, x=2048, y=1361), timeout=30)
+            has_tiles = response.ok
+        except requests.exceptions.RequestException as e:
+            # callers go on to reveal the browser panel, so this must not abort them.
+            # Only the class name: the exception stringifies the app id in the url.
+            log("Could not reach the tiles endpoint ({})".format(type(e).__name__))
+            has_tiles = False
 
         if not has_tiles:
             self.main.iface.messageBar().pushMessage(

--- a/travel_time_platform_plugin/tiles.py
+++ b/travel_time_platform_plugin/tiles.py
@@ -21,24 +21,45 @@ class TilesManager:
 
     def _get_url(self, identifier):
         app_id, _ = auth.get_app_id_and_api_key()
-        disable_https = QSettings().value(
-            "traveltime_platform/disable_https", False, type=bool
-        )
         return "https://tiles.traveltimeapp.com/{identifier}/{{z}}/{{x}}/{{y}}.png?key={app_id}&client=QGIS".format(
-            app_id=app_id, identifier=identifier, verify=not disable_https
+            app_id=app_id, identifier=identifier
         )
 
+    def _drop_retired_entries(self):
+        """A renamed or retired style would otherwise leave a dead browser entry"""
+        current = {self.browser_label(identifier) for identifier in self.tiles}
+        s = QgsSettings()
+        s.beginGroup("connections/xyz/items")
+        for label in s.childGroups():
+            if label.startswith("TravelTime - ") and label not in current:
+                s.remove(label)
+        s.endGroup()
+
     def add_tiles_to_browser(self):
+        self._drop_retired_entries()
+
         # We test access to tiles with API
-        test_url = self._get_url(list(self.tiles.keys())[0])
+        test_url = self._get_url(next(iter(self.tiles)))
+        verify = not QSettings().value(
+            "traveltime_platform/disable_https", False, type=bool
+        )
         try:
-            response = requests.get(test_url.format(z=12, x=2048, y=1361), timeout=30)
-            has_tiles = response.ok
-        except requests.exceptions.RequestException as e:
-            # callers go on to reveal the browser panel, so this must not abort them.
+            response = requests.get(
+                test_url.format(z=12, x=2048, y=1361), timeout=10, verify=verify
+            )
+        except (requests.exceptions.RequestException, OSError) as e:
+            # Callers go on to reveal the browser panel, so this must not abort them.
             # Only the class name: the exception stringifies the app id in the url.
-            log("Could not reach the tiles endpoint ({})".format(type(e).__name__))
-            has_tiles = False
+            log("Could not reach the tiles service ({})".format(type(e).__name__))
+            self.main.iface.messageBar().pushMessage(
+                "Warning",
+                tr("Could not reach the TravelTime tiles service."),
+                level=Qgis.MessageLevel.Warning,
+            )
+            return
+
+        # A proxy block page answers 200, so require an actual image
+        has_tiles = response.ok and response.content[:4] == b"\x89PNG"
 
         if not has_tiles:
             self.main.iface.messageBar().pushMessage(

--- a/travel_time_platform_plugin/tiles.py
+++ b/travel_time_platform_plugin/tiles.py
@@ -20,6 +20,10 @@ class TilesManager:
     def browser_label(self, identifier):
         return LABEL_PREFIX + self.tiles[identifier]
 
+    def default_browser_label(self):
+        """The entry the toolbar button probes for and selects"""
+        return self.browser_label(next(iter(self.tiles)))
+
     def _get_url(self, identifier):
         app_id, _ = auth.get_app_id_and_api_key()
         return "https://tiles.traveltimeapp.com/{identifier}/{{z}}/{{x}}/{{y}}.png?key={app_id}&client=QGIS".format(
@@ -31,19 +35,23 @@ class TilesManager:
         current = {self.browser_label(identifier) for identifier in self.tiles}
         s = QgsSettings()
         s.beginGroup("connections/xyz/items")
-        for label in s.childGroups():
-            if not label.startswith(LABEL_PREFIX) or label in current:
-                continue
+        retired = [
+            label
+            for label in s.childGroups()
+            if label.startswith(LABEL_PREFIX) and label not in current
             # only ours: the user may have kept an entry of their own under the prefix
-            if "traveltime" in s.value(f"{label}/url", ""):
-                s.remove(label)
+            and "traveltime" in s.value(f"{label}/url", "")
+        ]
+        for label in retired:
+            s.remove(label)
         s.endGroup()
+        if retired:
+            self.main.iface.reloadConnections()
 
     def add_tiles_to_browser(self):
         """Returns False when the layers were not registered, so callers do not
         add a second, contradictory reason for their absence."""
         self._drop_retired_entries()
-        self.main.iface.reloadConnections()
 
         # We test access to tiles with API
         test_url = self._get_url(next(iter(self.tiles)))
@@ -64,10 +72,22 @@ class TilesManager:
             )
             return False
 
-        # A proxy block page answers 200, so require an actual image
-        has_tiles = response.ok and response.content[:4] == b"\x89PNG"
+        log(
+            "Tiles probe answered {} ({} bytes)".format(
+                response.status_code, len(response.content)
+            )
+        )
 
-        if not has_tiles:
+        # A proxy block page answers 200, so an entitled account still needs an image
+        if response.ok and response.content[:4] != b"\x89PNG":
+            self.main.iface.messageBar().pushMessage(
+                "Warning",
+                tr("Unexpected answer from the TravelTime tiles service."),
+                level=Qgis.MessageLevel.Warning,
+            )
+            return False
+
+        if not response.ok:
             self.main.iface.messageBar().pushMessage(
                 "Info",
                 tr(

--- a/travel_time_platform_plugin/tiles.py
+++ b/travel_time_platform_plugin/tiles.py
@@ -5,6 +5,8 @@ from qgis.PyQt.QtCore import QSettings
 from . import auth
 from .utils import log, tr
 
+LABEL_PREFIX = "TravelTime - "
+
 
 class TilesManager:
     tiles = {
@@ -16,8 +18,7 @@ class TilesManager:
         self.main = main
 
     def browser_label(self, identifier):
-        """Name the browser entry carries, and what callers locate it by"""
-        return "TravelTime - " + self.tiles[identifier]
+        return LABEL_PREFIX + self.tiles[identifier]
 
     def _get_url(self, identifier):
         app_id, _ = auth.get_app_id_and_api_key()
@@ -31,12 +32,18 @@ class TilesManager:
         s = QgsSettings()
         s.beginGroup("connections/xyz/items")
         for label in s.childGroups():
-            if label.startswith("TravelTime - ") and label not in current:
+            if not label.startswith(LABEL_PREFIX) or label in current:
+                continue
+            # only ours: the user may have kept an entry of their own under the prefix
+            if "traveltime" in s.value(f"{label}/url", ""):
                 s.remove(label)
         s.endGroup()
 
     def add_tiles_to_browser(self):
+        """Returns False when the layers were not registered, so callers do not
+        add a second, contradictory reason for their absence."""
         self._drop_retired_entries()
+        self.main.iface.reloadConnections()
 
         # We test access to tiles with API
         test_url = self._get_url(next(iter(self.tiles)))
@@ -47,16 +54,15 @@ class TilesManager:
             response = requests.get(
                 test_url.format(z=12, x=2048, y=1361), timeout=10, verify=verify
             )
-        except (requests.exceptions.RequestException, OSError) as e:
-            # Callers go on to reveal the browser panel, so this must not abort them.
-            # Only the class name: the exception stringifies the app id in the url.
+        except OSError as e:
+            # Not the exception itself: it stringifies the app id in the url
             log("Could not reach the tiles service ({})".format(type(e).__name__))
             self.main.iface.messageBar().pushMessage(
                 "Warning",
                 tr("Could not reach the TravelTime tiles service."),
                 level=Qgis.MessageLevel.Warning,
             )
-            return
+            return False
 
         # A proxy block page answers 200, so require an actual image
         has_tiles = response.ok and response.content[:4] == b"\x89PNG"
@@ -69,17 +75,15 @@ class TilesManager:
                 ),
                 level=Qgis.MessageLevel.Info,
             )
-        else:
-            for identifier in self.tiles:
-                url = self._get_url(identifier)
-                label = self.browser_label(identifier)
+            return False
 
-                settings_path = f"connections/xyz/items/{label}"
-                s = QgsSettings()
-                s.setValue(f"{settings_path}/url", url)
-                s.setValue(f"{settings_path}/zmax", 20)
-                s.setValue(f"{settings_path}/zmin", 0)
-                s.setValue(f"{settings_path}/tilePixelRatio", 2)
+        s = QgsSettings()
+        for identifier in self.tiles:
+            settings_path = f"connections/xyz/items/{self.browser_label(identifier)}"
+            s.setValue(f"{settings_path}/url", self._get_url(identifier))
+            s.setValue(f"{settings_path}/zmax", 20)
+            s.setValue(f"{settings_path}/zmin", 0)
+            s.setValue(f"{settings_path}/tilePixelRatio", 2)
 
-                # Update GUI
-                self.main.iface.reloadConnections()
+        self.main.iface.reloadConnections()
+        return True

--- a/travel_time_platform_plugin/tiles.py
+++ b/travel_time_platform_plugin/tiles.py
@@ -8,18 +8,23 @@ from .utils import log, tr
 
 class TilesManager:
     tiles = {
-        "lux": tr("Lux"),
+        "osm-bright": tr("OSM Bright"),
+        "positron": tr("Positron"),
     }
 
     def __init__(self, main):
         self.main = main
+
+    def browser_label(self, identifier):
+        """Name the browser entry carries, and what callers locate it by"""
+        return "TravelTime - " + self.tiles[identifier]
 
     def _get_url(self, identifier):
         app_id, _ = auth.get_app_id_and_api_key()
         disable_https = QSettings().value(
             "traveltime_platform/disable_https", False, type=bool
         )
-        return "https://tiles.traveltime.com/{identifier}/{{z}}/{{x}}/{{y}}.png?key={app_id}&client=QGIS".format(
+        return "https://tiles.traveltimeapp.com/{identifier}/{{z}}/{{x}}/{{y}}.png?key={app_id}&client=QGIS".format(
             app_id=app_id, identifier=identifier, verify=not disable_https
         )
 
@@ -44,9 +49,9 @@ class TilesManager:
                 level=Qgis.MessageLevel.Info,
             )
         else:
-            for identifier, label in self.tiles.items():
+            for identifier in self.tiles:
                 url = self._get_url(identifier)
-                label = "TravelTime - " + label
+                label = self.browser_label(identifier)
 
                 settings_path = f"connections/xyz/items/{label}"
                 s = QgsSettings()

--- a/travel_time_platform_plugin/ui.py
+++ b/travel_time_platform_plugin/ui.py
@@ -2,9 +2,10 @@ import os
 import webbrowser
 
 try:
-    # QGIS >= 4 (replaces processing.gui.AlgorithmDialog, same interface)
+    # QGIS >= 4.2 home of the algorithm dialog; getParametersPanel below needs
+    # in_place and active_layer, which both classes set in __init__
     from processing.gui.algorithm_widget import AlgorithmWidget as AlgorithmDialog
-except (ModuleNotFoundError, ImportError):
+except ImportError:
     from processing.gui.AlgorithmDialog import AlgorithmDialog
 from processing.gui.ParametersPanel import ParametersPanel
 from qgis.gui import QgsAbstractProcessingParameterWidgetWrapper as Wrapper
@@ -16,7 +17,7 @@ try:
     from qgis.PyQt.QtWebKitWidgets import QWebView
 
     webkit_available = True
-except (ModuleNotFoundError, ImportError):
+except ImportError:
     webkit_available = False
 
 from processing.gui.wrappers import WidgetWrapper

--- a/travel_time_platform_plugin/ui.py
+++ b/travel_time_platform_plugin/ui.py
@@ -2,8 +2,7 @@ import os
 import webbrowser
 
 try:
-    # QGIS >= 4.2 home of the algorithm dialog; getParametersPanel below needs
-    # in_place and active_layer, which both classes set in __init__
+    # QGIS >= 4.2 home of the algorithm dialog; both expose in_place and active_layer
     from processing.gui.algorithm_widget import AlgorithmWidget as AlgorithmDialog
 except ImportError:
     from processing.gui.AlgorithmDialog import AlgorithmDialog


### PR DESCRIPTION
Follow-up to #98, fixing what a review of it turned up — plus the CI failure, which turned out to be a real product bug rather than a test artefact. It branches off #98, so it merges into that rather than master, and none of it changes the QGIS 4 migration itself.

- Background tiles have been broken for everyone: the host the plugin called is decommissioned and now answers with a placeholder certificate. Worse, that failure took the whole toolbar button down with it, so clicking it did nothing and said nothing. Tiles now point at the current service and the styles it actually serves, an unreachable service no longer stops the browser panel from opening, and the message says which of the two problems you have rather than always suggesting you buy access.
- Upgrading users kept a dead tile entry in their browser forever, because nothing ever removed one. Retired entries are cleaned up now, and only ones the plugin wrote.
- The "disable HTTPS verification" setting never applied to tiles — it was read and then thrown away. It works now, which matters because that setting is what gets users behind a TLS proxy working at all.
- Call logging switched itself back on after every restart, for anyone who had ever opened the settings dialog — so URLs, parameters and search payloads went to the message log unasked. Credentials were already redacted there and still are, now with a test behind it.
- The API key and application id were being written to the plugin's response cache in plain text on every call, in an unprotected file — while the same two values are deliberately hidden from the logs and otherwise kept in QGIS's encrypted store. They stay out of the cache now, and a cache left behind by an earlier version is cleared once on first start.
- An API error arriving in an unexpected shape crashed the error handler instead of reporting the error, which for the express tools meant the user saw nothing at all. An SSL failure also never showed the one message that tells you how to fix it, because that handler sat where SSL errors never arrive.
- The time map's union and intersection output, and express tool error reporting, had no tests at all even though #98 rewrote lines inside both. Covered now, along with the two fixes above.
- The QGIS 4.0 test image never starts the suite and only burned the job timeout, so it is out of the matrix. The weekly run can no longer be cancelled by a push, which is what would have caught the dead tiles host months ago.
- Dropped a version check that can no longer be reached, some dead error handling, renamed two variables that had come to look like each other, and cut comments back to the constraint they described.

CI is green on QGIS 3.40, 3.44 and 4.2 — the first green run since December.
