### PR TITLE
Fix the response-cache clean-up breaking the other QGIS generation

### DIFF
--- a/travel_time_platform_plugin/algorithms/base.py
+++ b/travel_time_platform_plugin/algorithms/base.py
@@ -416,24 +416,22 @@ class ProcessingAlgorithmBase(AlgorithmBase):
             log(e)
             raise QgsProcessingException("Could not decode response") from None
 
-        # The API answers with an object; a gateway in front of it may not
-        if not isinstance(response_data, dict):
-            response_data = {}
-
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
+            # a gateway in front of the API may not answer with an object
+            error_data = response_data if isinstance(response_data, dict) else {}
             nice_info = "\n".join(
                 "\t{}:\t{}".format(k, v)
-                for k, v in response_data.get("additional_info", {}).items()
+                for k, v in error_data.get("additional_info", {}).items()
             )
             feedback.reportError(
                 tr(
                     "Received error from the API.\nError code : {}\nDescription : {}\nSee : {}\nAddtionnal info :\n{}"
                 ).format(
-                    response_data.get("error_code", response.status_code),
-                    response_data.get("description", response.reason),
-                    response_data.get("documentation_link", ""),
+                    error_data.get("error_code", response.status_code),
+                    error_data.get("description", response.reason),
+                    error_data.get("documentation_link", ""),
                     nice_info,
                 ),
                 fatalError=True,

--- a/travel_time_platform_plugin/cache.py
+++ b/travel_time_platform_plugin/cache.py
@@ -8,6 +8,7 @@ from .libraries.requests_cache.backends import DbCache
 from .utils import log
 
 PURGED_SETTING = "traveltime_platform/cache_credentials_purged"
+SIBLINGS_PURGED_SETTING = "traveltime_platform/sibling_caches_purged"
 
 
 class CredentialFreeCache(DbCache):
@@ -60,24 +61,33 @@ class Cache:
         self._purge_credentials_once()
 
     def _purge_credentials_once(self):
-        """Entries from earlier versions hold credentials, and nothing else evicts them"""
+        """Entries from earlier versions hold credentials, and nothing else evicts them.
+
+        Tracked per cache file: a sibling another QGIS holds open must be retried
+        without re-wiping this generation's healthy cache every start.
+        """
         settings = QSettings()
-        if settings.value(PURGED_SETTING, False, type=bool):
+        if not settings.value(PURGED_SETTING, False, type=bool):
+            try:
+                self.clear()
+            except Exception as e:
+                # runs during plugin import, and vacuum needs the file to itself
+                log(f"Could not purge the response cache, will retry next start: {e}")
+            else:
+                settings.setValue(PURGED_SETTING, True)
+
+        if settings.value(SIBLINGS_PURGED_SETTING, False, type=bool):
             return
-        try:
-            self.clear()
-        except Exception as e:
-            # runs during plugin import, and vacuum needs the file to itself
-            log(f"Could not purge the response cache, will retry next start: {e}")
-            return
-        # Separately, so a file another QGIS holds open cannot make the clear repeat.
-        # Cleared, not unlinked: that QGIS creates its tables only at startup.
-        try:
-            for path in self._sibling_cache_paths():
+        # Cleared, not unlinked: that QGIS creates its tables only at startup
+        cleared = True
+        for path in self._sibling_cache_paths():
+            try:
                 DbCache(os.path.splitext(path)[0]).clear()
-        except Exception as e:
-            log(f"Could not clear another QGIS generation's response cache: {e}")
-        settings.setValue(PURGED_SETTING, True)
+            except Exception as e:
+                log(f"Could not clear a cache of another QGIS generation: {e}")
+                cleared = False
+        if cleared:
+            settings.setValue(SIBLINGS_PURGED_SETTING, True)
 
     def _generations_root(self):
         """Splits our cache path into the dir holding one entry per QGIS generation
@@ -92,10 +102,16 @@ class Cache:
     def _sibling_cache_paths(self):
         """CacheLocation is per QGIS generation, so the other generation's file is ours"""
         generations, relative = self._generations_root()
+        # normalised: Qt reports / separators where os.path.join would write \
+        ours = os.path.normcase(os.path.normpath(self.path))
         paths = (
             os.path.join(generations, d, relative) for d in os.listdir(generations)
         )
-        return [p for p in paths if p != self.path and os.path.isfile(p)]
+        return [
+            p
+            for p in paths
+            if os.path.normcase(os.path.normpath(p)) != ours and os.path.isfile(p)
+        ]
 
 
 instance = Cache()

--- a/travel_time_platform_plugin/cache.py
+++ b/travel_time_platform_plugin/cache.py
@@ -66,20 +66,23 @@ class Cache:
             return
         try:
             self.clear()
-            for path in self._sibling_cache_paths():
-                os.remove(path)
         except Exception as e:
             # runs during plugin import, and vacuum needs the file to itself
             log(f"Could not purge the response cache, will retry next start: {e}")
             return
+        # Separately, so a file another QGIS holds open cannot make the clear repeat.
+        # Cleared, not unlinked: that QGIS creates its tables only at startup.
+        try:
+            for path in self._sibling_cache_paths():
+                DbCache(os.path.splitext(path)[0]).clear()
+        except Exception as e:
+            log(f"Could not clear another QGIS generation's response cache: {e}")
         settings.setValue(PURGED_SETTING, True)
 
     def _sibling_cache_paths(self):
         """CacheLocation is per QGIS generation, so the other generation's file is ours"""
         name = os.path.basename(self.path)
         generations = os.path.dirname(os.path.dirname(self.path))
-        if not os.path.isdir(generations):
-            return []
         paths = (os.path.join(generations, d, name) for d in os.listdir(generations))
         return [p for p in paths if p != self.path and os.path.isfile(p)]
 

--- a/travel_time_platform_plugin/cache.py
+++ b/travel_time_platform_plugin/cache.py
@@ -79,11 +79,22 @@ class Cache:
             log(f"Could not clear another QGIS generation's response cache: {e}")
         settings.setValue(PURGED_SETTING, True)
 
+    def _generations_root(self):
+        """Splits our cache path into the dir holding one entry per QGIS generation
+        and the part below it, which Windows nests under an extra "cache" level."""
+        relative = os.path.basename(self.path)
+        generation = os.path.dirname(self.path)
+        if os.path.basename(generation).lower() == "cache":
+            relative = os.path.join(os.path.basename(generation), relative)
+            generation = os.path.dirname(generation)
+        return os.path.dirname(generation), relative
+
     def _sibling_cache_paths(self):
         """CacheLocation is per QGIS generation, so the other generation's file is ours"""
-        name = os.path.basename(self.path)
-        generations = os.path.dirname(os.path.dirname(self.path))
-        paths = (os.path.join(generations, d, name) for d in os.listdir(generations))
+        generations, relative = self._generations_root()
+        paths = (
+            os.path.join(generations, d, relative) for d in os.listdir(generations)
+        )
         return [p for p in paths if p != self.path and os.path.isfile(p)]
 
 

--- a/travel_time_platform_plugin/tests/tests_misc.py
+++ b/travel_time_platform_plugin/tests/tests_misc.py
@@ -131,6 +131,7 @@ class MiscTest(TestCaseBase):
             other.save_response("legacy-key", self._legacy_cache_entry())
             backend.save_response("legacy-key", self._legacy_cache_entry())
             settings.remove(cache.PURGED_SETTING)
+            settings.remove(cache.SIBLINGS_PURGED_SETTING)
             cache.instance._purge_credentials_once()
 
             self.assertFalse(backend.has_key("legacy-key"))
@@ -155,9 +156,22 @@ class MiscTest(TestCaseBase):
             finally:
                 cache.instance.clear = original_clear
             self.assertFalse(settings.value(cache.PURGED_SETTING, False, type=bool))
+
+            # a sibling we cannot clear — one another QGIS holds open — must be
+            # retried, not recorded as done
+            settings.remove(cache.SIBLINGS_PURGED_SETTING)
+            unclearable = os.path.join(sibling_dir, "not-a-database.sqlite")
+            with open(unclearable, "wb") as f:
+                f.write(b"definitely not sqlite")
+            cache.instance._sibling_cache_paths = lambda: [unclearable]
+            cache.instance._purge_credentials_once()
+            self.assertFalse(
+                settings.value(cache.SIBLINGS_PURGED_SETTING, False, type=bool)
+            )
         finally:
             cache.instance._sibling_cache_paths = original_siblings
             settings.setValue(cache.PURGED_SETTING, True)
+            settings.setValue(cache.SIBLINGS_PURGED_SETTING, True)
             shutil.rmtree(sibling_dir, ignore_errors=True)
 
     def test_tiles_keeps_live_entries_when_probe_fails(self):

--- a/travel_time_platform_plugin/tests/tests_misc.py
+++ b/travel_time_platform_plugin/tests/tests_misc.py
@@ -102,10 +102,16 @@ class MiscTest(TestCaseBase):
         ).prepare()
         return response
 
-    def test_cache_finds_the_other_generations_file(self):
-        generations = os.path.dirname(os.path.dirname(cache.instance.path))
+    def _make_sibling_cache_dir(self):
+        """A stand-in for the other QGIS generation, wherever this platform puts it"""
+        generations, relative = cache.instance._generations_root()
         sibling_dir = tempfile.mkdtemp(dir=generations)
-        sibling = os.path.join(sibling_dir, os.path.basename(cache.instance.path))
+        sibling = os.path.join(sibling_dir, relative)
+        os.makedirs(os.path.dirname(sibling), exist_ok=True)
+        return sibling_dir, sibling
+
+    def test_cache_finds_the_other_generations_file(self):
+        sibling_dir, sibling = self._make_sibling_cache_dir()
         try:
             open(sibling, "wb").close()
             self.assertIn(sibling, cache.instance._sibling_cache_paths())
@@ -116,9 +122,7 @@ class MiscTest(TestCaseBase):
     def test_cache_purges_once(self):
         backend = cache.instance.cached_requests.cache
         settings = QSettings()
-        generations = os.path.dirname(os.path.dirname(cache.instance.path))
-        sibling_dir = tempfile.mkdtemp(dir=generations)
-        sibling = os.path.join(sibling_dir, os.path.basename(cache.instance.path))
+        sibling_dir, sibling = self._make_sibling_cache_dir()
         other = DbCache(os.path.splitext(sibling)[0])
         # only the synthetic one: a real other generation may be running
         original_siblings = cache.instance._sibling_cache_paths

--- a/travel_time_platform_plugin/tests/tests_misc.py
+++ b/travel_time_platform_plugin/tests/tests_misc.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import shutil
+import tempfile
 
 import processing
 import requests
@@ -20,6 +21,7 @@ from qgis.utils import iface
 from .. import auth, cache, tiles
 from ..algorithms import base
 from ..constants import CREDENTIAL_HEADERS
+from ..libraries.requests_cache.backends import DbCache
 from ..utils import log
 from .base import TestCaseBase
 
@@ -94,26 +96,45 @@ class MiscTest(TestCaseBase):
         response.status_code = 200
         response._content = b"{}"
         response.request = requests.Request(
-            "POST", "https://api.traveltimeapp.com/v4/time-map"
+            "POST",
+            "https://api.traveltimeapp.com/v4/time-map",
+            headers={"X-Api-Key": "secret-legacy-key"},
         ).prepare()
         return response
+
+    def test_cache_finds_the_other_generations_file(self):
+        generations = os.path.dirname(os.path.dirname(cache.instance.path))
+        sibling_dir = tempfile.mkdtemp(dir=generations)
+        sibling = os.path.join(sibling_dir, os.path.basename(cache.instance.path))
+        try:
+            open(sibling, "wb").close()
+            self.assertIn(sibling, cache.instance._sibling_cache_paths())
+            self.assertNotIn(cache.instance.path, cache.instance._sibling_cache_paths())
+        finally:
+            shutil.rmtree(sibling_dir, ignore_errors=True)
 
     def test_cache_purges_once(self):
         backend = cache.instance.cached_requests.cache
         settings = QSettings()
-        # the cache dir is per QGIS generation, so the other generation's file is ours
         generations = os.path.dirname(os.path.dirname(cache.instance.path))
-        sibling_dir = os.path.join(generations, "QGIS_other")
-        os.makedirs(sibling_dir, exist_ok=True)
+        sibling_dir = tempfile.mkdtemp(dir=generations)
         sibling = os.path.join(sibling_dir, os.path.basename(cache.instance.path))
+        other = DbCache(os.path.splitext(sibling)[0])
+        # only the synthetic one: a real other generation may be running
+        original_siblings = cache.instance._sibling_cache_paths
+        cache.instance._sibling_cache_paths = lambda: [sibling]
         try:
-            with open(sibling, "wb") as f:
-                f.write(b"pretend this holds X-Api-Key")
+            other.save_response("legacy-key", self._legacy_cache_entry())
             backend.save_response("legacy-key", self._legacy_cache_entry())
             settings.remove(cache.PURGED_SETTING)
             cache.instance._purge_credentials_once()
+
             self.assertFalse(backend.has_key("legacy-key"))
-            self.assertFalse(os.path.exists(sibling))
+            # the other generation loses its entries but keeps usable tables,
+            # or its running QGIS would raise on every request from then on
+            self.assertFalse(other.has_key("legacy-key"))
+            with open(sibling, "rb") as f:
+                self.assertNotIn(b"secret-legacy-key", f.read())
             self.assertTrue(settings.value(cache.PURGED_SETTING, False, type=bool))
 
             # having run once, it must not wipe a healthy cache on every start
@@ -131,6 +152,7 @@ class MiscTest(TestCaseBase):
                 cache.instance.clear = original_clear
             self.assertFalse(settings.value(cache.PURGED_SETTING, False, type=bool))
         finally:
+            cache.instance._sibling_cache_paths = original_siblings
             settings.setValue(cache.PURGED_SETTING, True)
             shutil.rmtree(sibling_dir, ignore_errors=True)
 
@@ -156,13 +178,12 @@ class MiscTest(TestCaseBase):
                 tiles.requests.get = fake_get
                 try:
                     self.assertFalse(tiles_manager.add_tiles_to_browser())
+                    self.assertIsNone(settings.value(f"{retired}/url"))
+                    # the user may have kept an entry of their own under the prefix
+                    self.assertIsNotNone(settings.value(f"{mine}/url"))
                 finally:
                     tiles.requests.get = original_get
-
-                # ours and retired goes; the user's own entry under the prefix stays
-                self.assertIsNone(settings.value(f"{retired}/url"))
-                self.assertIsNotNone(settings.value(f"{mine}/url"))
-                settings.remove(mine)
+                    settings.remove(mine)
 
         # a failed probe must not have cost the user their working entries
         tiles_manager.add_tiles_to_browser()

--- a/travel_time_platform_plugin/tiles.py
+++ b/travel_time_platform_plugin/tiles.py
@@ -78,15 +78,6 @@ class TilesManager:
             )
         )
 
-        # A proxy block page answers 200, so an entitled account still needs an image
-        if response.ok and response.content[:4] != b"\x89PNG":
-            self.main.iface.messageBar().pushMessage(
-                "Warning",
-                tr("Unexpected answer from the TravelTime tiles service."),
-                level=Qgis.MessageLevel.Warning,
-            )
-            return False
-
         if not response.ok:
             self.main.iface.messageBar().pushMessage(
                 "Info",
@@ -94,6 +85,15 @@ class TilesManager:
                     "TravelTime also offers some background maps for their users. <a href='https://docs.traveltime.com/api/tiles/getting-started'>Click here to request access !</a>"
                 ),
                 level=Qgis.MessageLevel.Info,
+            )
+            return False
+
+        # A proxy block page answers 200, so an entitled account still needs an image
+        if response.content[:4] != b"\x89PNG":
+            self.main.iface.messageBar().pushMessage(
+                "Warning",
+                tr("Unexpected answer from the TravelTime tiles service."),
+                level=Qgis.MessageLevel.Warning,
             )
             return False
 


### PR DESCRIPTION
Fixes two bugs in the cache clean-up that #99 added, both found reviewing that work. Branches off #98, so it merges into that; #98 should not go to master before this.

- The clean-up deleted the cache file belonging to the *other* QGIS generation. If that QGIS was running, it recreated the file without its tables and then failed on every API call until restarted — and on Windows it did this to the generation you were actually using, not the other one. It now empties the file in place, which removes the credentials just as thoroughly and leaves whoever has it open unharmed.
- On Windows the clean-up looked in the wrong place, so a user moving from QGIS 3 to QGIS 4 would have kept the old file with the credentials still in it, while the release notes said otherwise.
- A file that could not be cleaned — because another QGIS had it open — was recorded as done and never retried. It is now tracked separately from this generation's own cache, so it gets another go on the next start without wiping a healthy cache each time.

Also two smaller things noticed in passing: an unexpected reply from the API no longer changes what a successful call returns, and the tile-service check reads in one direction instead of two.
