### PR TITLE
Bump qgis-plugin-ci to 2.10.0

### DIFF
--- a/.github/workflows/deploy_to_repo.yaml
+++ b/.github/workflows/deploy_to_repo.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.13
 
       - name: Install qgis-plugin-ci
-        run: pip install qgis-plugin-ci==2.8.10
+        run: pip install qgis-plugin-ci==2.10.0
 
       - name: Deploy to QGIS plugin repository
         env:


### PR DESCRIPTION
Our release tool was pinned to a December 2024 release. This moves it to the current one, which keeps the same command line and produces a byte-identical archive for us - I built the plugin with both to check, and the version, experimental flag and all three metadata urls come out the same.

It also opens up something worth doing separately: the new version can publish with a per-plugin token from plugins.qgis.org instead of an OSGeo username and password, so CI would no longer need the account password as a secret. That needs a token creating first, so it is not part of this.

To be clear about what this does not do: it has no bearing on the 1.11.0-rc1 upload failure. That is a link check on the plugins.qgis.org side, and the same check runs whichever way we upload.
