### PR TITLE
chore: point the plugin contact email at TravelTime

### DIFF
--- a/travel_time_platform_plugin/metadata.txt
+++ b/travel_time_platform_plugin/metadata.txt
@@ -7,7 +7,7 @@ description=Get travel time polygons from the TravelTime API directly from QGIS
 about=This plugin adds a toolbar and processing algorithms allowing to query the TravelTime API directly from QGIS. The TravelTime API allows to obtain polygons based on actual travel time using several transport modes rather, allowing for much more accurate results than simple distance calculations.
 category=Vector
 author=Olivier Dalang
-email=olivier.dalang@gmail.com
+email=chris@traveltime.com
 version=dev
 
 # Optional items:


### PR DESCRIPTION
## Why

The plugin's contact address on plugins.qgis.org is still the original author's personal Gmail. That address is what QGIS sends approval and administrative mail to, so the release path currently depends on someone outside TravelTime reading their inbox.

It also blocks the current release: the validation mail for `1.11.0-rc1` says *"make sure that the plugin email is confirmed so that it can be approved"*.

## Why it has to change here, not just on the website

The address has already been updated on the plugin page, but that alone would not hold. On every version upload — including API uploads — QGIS-Django runs `_main_plugin_update()`, which refreshes these fields from the uploaded `metadata.txt`:

```python
metadata_fields = ["author", "email", "description", "about",
                   "homepage", "tracker", "repository"]
```

So publishing `1.11.0` would silently revert the contact address to the old one. This change makes the repo agree with the site.

## What is not changing

- `author=Olivier Dalang` stays. He wrote the plugin and keeps the credit; only the admin contact address moves.
- `maintainer` is not in the metadata-refresh list above, so the maintainer change made on the site is unaffected by uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)