### PR TITLE
chore: publish with a plugin-scoped QGIS token instead of a shared login

### DIFF
--- a/.github/workflows/deploy_to_repo.yaml
+++ b/.github/workflows/deploy_to_repo.yaml
@@ -21,8 +21,10 @@ jobs:
       - name: Install qgis-plugin-ci
         run: pip install qgis-plugin-ci==2.10.0
 
+      # A plugin-scoped token from plugins.qgis.org, not a person's login. Note
+      # that qgis-plugin-ci exits 2 if a token and OSGeo credentials are both
+      # passed, so --osgeo-username/--osgeo-password must stay gone.
       - name: Deploy to QGIS plugin repository
         env:
-          OSGEO_USERNAME: ${{ secrets.OSGEO_USERNAME }}
-          OSGEO_PASSWORD: ${{ secrets.OSGEO_PASSWORD }}
-        run: qgis-plugin-ci release --osgeo-username "$OSGEO_USERNAME" --osgeo-password "$OSGEO_PASSWORD" "${GITHUB_REF##*/}"
+          QGIS_TOKEN: ${{ secrets.QGIS_TOKEN }}
+        run: qgis-plugin-ci release --qgis-token "$QGIS_TOKEN" "${GITHUB_REF##*/}"


### PR DESCRIPTION
## ⚠️ Do not merge until the `QGIS_TOKEN` secret exists

Merging this before the secret is added will break the next tag push. Order:

- [ ] **Chris** creates a token at https://plugins.qgis.org/plugins/travel_time_platform_plugin/tokens/create/
- [ ] **A repo admin** adds it as the `QGIS_TOKEN` repository secret (managing secrets needs admin; Chris has `push` only)
- [ ] Merge this PR
- [ ] After the first successful release, delete the now-unused `OSGEO_USERNAME` / `OSGEO_PASSWORD` secrets

## Why

Releases currently authenticate to plugins.qgis.org as OSGeo user `redl`, using a password last set on **2020-02-27**. Nobody at TravelTime holds it, and it isn't recoverable from GitHub — Actions secrets are write-only. The `1.11.0-rc1` upload on 2026-08-13 went out under that account.

That makes every release dependent on one individual's personal credentials. A token from plugins.qgis.org is scoped to this plugin alone, is revocable independently, and belongs to whoever generates it.

## Why the old flags are deleted rather than kept

`qgis-plugin-ci` refuses to run with both auth methods (`release.py`):

```python
if qgis_token and (osgeo_username or osgeo_password):
    logger.error("Not possible to have both parameters OSGeo and QGIS token")
    sys.exit(2)
```

So there is no "fall back to the password if the token is missing" option — it's one or the other. Note this also means the token takes a different upload path (`upload_plugin_to_osgeo_with_token`, an HTTP API call) rather than the XML-RPC path used for username/password.

`--qgis-token` is available in the pinned `qgis-plugin-ci==2.10.0` already in use here; it has no environment-variable default, hence passing it explicitly.

## Testing

This can only be exercised by an actual tag push, since `deploy_to_repo.yaml` triggers on tags. The YAML parses and the step resolves to:

```
qgis-plugin-ci release --qgis-token "$QGIS_TOKEN" "${GITHUB_REF##*/}"
```

The next release (`1.11.0`) will be the first real run. If the token is wrong or missing, the deploy job fails without publishing anything, so the failure mode is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)