### PR TITLE
fix: splash screen is unreadable on QGIS 4 (Qt6 drops malformed rgba)

### DIFF
--- a/travel_time_platform_plugin/ui/SplashScreen.ui
+++ b/travel_time_platform_plugin/ui/SplashScreen.ui
@@ -32,7 +32,7 @@
                         <item>
                                 <widget class="QWidget" name="widget_2" native="true">
                                         <property name="styleSheet">
-                                                <string notr="true">background-color: rgba(19,28,76);</string>
+                                                <string notr="true">background-color: rgb(19,28,76);</string>
                                         </property>
                                         <layout class="QVBoxLayout" name="verticalLayout">
                                                 <item>


### PR DESCRIPTION
## Symptom

On QGIS 4, the TravelTime splash screen opens with the logo, the "Don't show again" checkbox and the OK button, but **no text at all** — just a large blank area. Found while desktop-testing `1.11.0-rc1` on QGIS 4.2.1. QGIS 3.x is unaffected.

## Cause

`SplashScreen.ui` asks for:

```
background-color: rgba(19,28,76);
```

That is an `rgba()` with only three components. Qt5 warns and then recovers, painting the navy anyway. **Qt6 discards the declaration entirely**, so the panel stays the default light grey — and every text span in that dialog is `color:#ffffff`.

White text on a near-white background. The content was always being drawn; it just wasn't visible. The logo survives because it's a pixmap, not a styled colour.

Rendering the stylesheet offscreen and sampling the resulting pixel:

| Stylesheet | Qt5 (QGIS 3.40.12) | Qt6 (QGIS 4.2.1) |
|---|---|---|
| `rgba(19,28,76)` | `rgb(19,28,76)` navy | `rgb(239,239,239)` **grey** |
| `rgb(19,28,76)` | navy | navy |
| `rgba(19,28,76,255)` | navy | navy |

## Fix

One character: `rgba(` → `rgb(`. Verified by loading the real `SplashScreen.ui` in both QGIS 3.40.12 and 4.2.1 and sampling the panel background — `rgb(19,28,76)` on both.

It also silences a warning QGIS has been printing on every single launch, in both generations:

```
QCssParser::parseColorValue: Specified color with alpha value but no alpha given: 'rgba 19,28,76'
```

That warning was visible in the QGIS 4 verification output during the `1.11.0` review and was mistaken for Qt boilerplate. Worth remembering that QCssParser warnings are load-bearing on Qt6 in a way they weren't on Qt5.

## Scope

`SplashScreen.ui:35` was the only malformed colour in the repo. Audited every stylesheet in the plugin:

- the two `rgba(255,255,255,0)` in `ConfigDialog.ui` are correctly 4-component
- all remaining stylesheets are `font-style`/`color` only
- no stylesheets are set from Python

## Testing

Needs a `1.11.0-rc2` to verify through the real install path, since the splash only appears on plugin load in a desktop session.
